### PR TITLE
Critical Bug Fix on Account Withdrawl Request

### DIFF
--- a/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Application.Contracts/EasyAbp/PaymentService/Prepayment/WithdrawalRequests/Dtos/WithdrawalRequestDto.cs
+++ b/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Application.Contracts/EasyAbp/PaymentService/Prepayment/WithdrawalRequests/Dtos/WithdrawalRequestDto.cs
@@ -4,7 +4,7 @@ using Volo.Abp.Application.Dtos;
 namespace EasyAbp.PaymentService.Prepayment.WithdrawalRequests.Dtos
 {
     [Serializable]
-    public class WithdrawalRequestDto : FullAuditedEntityDto<Guid>
+    public class WithdrawalRequestDto : ExtensibleFullAuditedEntityDto<Guid>
     {
         public Guid AccountId { get; set; }
 

--- a/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
+++ b/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
@@ -115,7 +115,7 @@ namespace EasyAbp.PaymentService.Prepayment.Accounts
 
             ClearPendingWithdrawal();
             
-            ChangeBalance(-balanceToChange);
+            ChangeBalance(balanceToChange);
         }
         
         public void CancelWithdrawal()

--- a/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
+++ b/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
@@ -111,11 +111,11 @@ namespace EasyAbp.PaymentService.Prepayment.Accounts
         
         public void CompleteWithdrawal()
         {
-            decimal orginalPendingWithdrawalAmount = PendingWithdrawalAmount;
+            var balanceToChange = -PendingWithdrawalAmount;
 
             ClearPendingWithdrawal();
             
-            ChangeBalance(-orginalPendingWithdrawalAmount);
+            ChangeBalance(-balanceToChange);
         }
         
         public void CancelWithdrawal()

--- a/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
+++ b/modules/EasyAbp.PaymentService.Prepayment/src/EasyAbp.PaymentService.Prepayment.Domain/EasyAbp/PaymentService/Prepayment/Accounts/Account.cs
@@ -111,9 +111,11 @@ namespace EasyAbp.PaymentService.Prepayment.Accounts
         
         public void CompleteWithdrawal()
         {
+            decimal orginalPendingWithdrawalAmount = PendingWithdrawalAmount;
+
             ClearPendingWithdrawal();
             
-            ChangeBalance(-PendingWithdrawalAmount);
+            ChangeBalance(-orginalPendingWithdrawalAmount);
         }
         
         public void CancelWithdrawal()


### PR DESCRIPTION
The orginal code will always make account balance unchanged and result in something like ` ChangeBalance(0)` since the PendingWithdrawalAmount is first cleared in the `ClearPendingWithdrawal` method